### PR TITLE
added sysex support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.swp
+*.o
+*.svn
+*.DS_STORE

--- a/src/Experimental/HIDUINO_MIDI_SYSEX/Board/LEDs.h
+++ b/src/Experimental/HIDUINO_MIDI_SYSEX/Board/LEDs.h
@@ -1,0 +1,110 @@
+/*
+             LUFA Library
+     Copyright (C) Dean Camera, 2010.
+              
+  dean [at] fourwalledcubicle [dot] com
+      www.fourwalledcubicle.com
+*/
+
+/*
+  Copyright 2010  Dean Camera (dean [at] fourwalledcubicle [dot] com)
+
+  Permission to use, copy, modify, distribute, and sell this 
+  software and its documentation for any purpose is hereby granted
+  without fee, provided that the above copyright notice appear in 
+  all copies and that both that the copyright notice and this
+  permission notice and warranty disclaimer appear in supporting 
+  documentation, and that the name of the author not be used in 
+  advertising or publicity pertaining to distribution of the 
+  software without specific, written prior permission.
+
+  The author disclaim all warranties with regard to this
+  software, including all implied warranties of merchantability
+  and fitness.  In no event shall the author be liable for any
+  special, indirect or consequential damages or any damages
+  whatsoever resulting from loss of use, data or profits, whether
+  in an action of contract, negligence or other tortious action,
+  arising out of or in connection with the use or performance of
+  this software.
+*/
+
+/*
+   Board LEDs driver for the Benito board, from www.dorkbotpdx.org.
+*/
+
+#ifndef __LEDS_ARDUINOUNO_H__
+#define __LEDS_ARDUINOUNO_H__
+
+	/* Includes: */
+		#include <avr/io.h>
+
+/* Enable C linkage for C++ Compilers: */
+		#if defined(__cplusplus)
+			extern "C" {
+		#endif
+
+	/* Preprocessor Checks: */
+		#if !defined(INCLUDE_FROM_LEDS_H)
+			#error Do not include this file directly. Include LUFA/Drivers/Board/LEDS.h instead.
+		#endif
+
+	/* Public Interface - May be used in end-application: */
+		/* Macros: */
+			/** LED mask for the first LED on the board. */
+			#define LEDS_LED1        (1 << 5)
+
+			/** LED mask for the second LED on the board. */
+			#define LEDS_LED2        (1 << 4)
+
+			/** LED mask for all the LEDs on the board. */
+			#define LEDS_ALL_LEDS    (LEDS_LED1 | LEDS_LED2)
+
+			/** LED mask for the none of the board LEDs */
+			#define LEDS_NO_LEDS     0
+
+		/* Inline Functions: */
+		#if !defined(__DOXYGEN__)
+			static inline void LEDs_Init(void)
+			{
+				DDRD  |= LEDS_ALL_LEDS;
+				PORTD |= LEDS_ALL_LEDS;
+			}
+			
+			static inline void LEDs_TurnOnLEDs(const uint8_t LEDMask)
+			{
+				PORTD &= ~LEDMask;
+			}
+
+			static inline void LEDs_TurnOffLEDs(const uint8_t LEDMask)
+			{
+				PORTD |= LEDMask;
+			}
+
+			static inline void LEDs_SetAllLEDs(const uint8_t LEDMask)
+			{
+				PORTD = ((PORTD | LEDS_ALL_LEDS) & ~LEDMask);
+			}
+			
+			static inline void LEDs_ChangeLEDs(const uint8_t LEDMask, const uint8_t ActiveMask)
+			{
+				PORTD = ((PORTD | ActiveMask) & ~LEDMask);
+			}
+
+			static inline void LEDs_ToggleLEDs(const uint8_t LEDMask)
+			{
+				PORTD ^= LEDMask;
+			}
+			
+			static inline uint8_t LEDs_GetLEDs(void) ATTR_WARN_UNUSED_RESULT;
+			static inline uint8_t LEDs_GetLEDs(void)
+			{
+				return (PORTD & LEDS_ALL_LEDS);
+			}
+		#endif
+
+	/* Disable C linkage for C++ Compilers: */
+		#if defined(__cplusplus)
+			}
+		#endif
+		
+#endif

--- a/src/Experimental/HIDUINO_MIDI_SYSEX/Descriptors.c
+++ b/src/Experimental/HIDUINO_MIDI_SYSEX/Descriptors.c
@@ -1,0 +1,329 @@
+/*
+             LUFA Library
+     Copyright (C) Dean Camera, 2010.
+
+  dean [at] fourwalledcubicle [dot] com
+           www.lufa-lib.org
+*/
+
+/*
+  Copyright 2010  Dean Camera (dean [at] fourwalledcubicle [dot] com)
+
+  Permission to use, copy, modify, distribute, and sell this
+  software and its documentation for any purpose is hereby granted
+  without fee, provided that the above copyright notice appear in
+  all copies and that both that the copyright notice and this
+  permission notice and warranty disclaimer appear in supporting
+  documentation, and that the name of the author not be used in
+  advertising or publicity pertaining to distribution of the
+  software without specific, written prior permission.
+
+  The author disclaim all warranties with regard to this
+  software, including all implied warranties of merchantability
+  and fitness.  In no event shall the author be liable for any
+  special, indirect or consequential damages or any damages
+  whatsoever resulting from loss of use, data or profits, whether
+  in an action of contract, negligence or other tortious action,
+  arising out of or in connection with the use or performance of
+  this software.
+*/
+
+/** \file
+ *
+ *  USB Device Descriptors, for library use when in USB device mode. Descriptors are special
+ *  computer-readable structures which the host requests upon device enumeration, to determine
+ *  the device's capabilities and functions.
+ */
+
+#include "Descriptors.h"
+
+/** Device descriptor structure. This descriptor, located in FLASH memory, describes the overall
+ *  device characteristics, including the supported USB version, control endpoint size and the
+ *  number of device configurations. The descriptor is read out by the USB host when the enumeration
+ *  process begins.
+ */
+const USB_Descriptor_Device_t PROGMEM DeviceDescriptor =
+{
+	.Header                 = {.Size = sizeof(USB_Descriptor_Device_t), .Type = DTYPE_Device},
+
+	.USBSpecification       = VERSION_BCD(01.10),
+	.Class                  = USB_CSCP_NoDeviceClass,
+	.SubClass               = USB_CSCP_NoDeviceSubclass,
+	.Protocol               = USB_CSCP_NoDeviceProtocol,
+
+	.Endpoint0Size          = FIXED_CONTROL_ENDPOINT_SIZE,
+
+	.VendorID               = 0x03EB,
+	.ProductID              = 0x2048,
+	.ReleaseNumber          = VERSION_BCD(00.01),
+
+	.ManufacturerStrIndex   = 0x01,
+	.ProductStrIndex        = 0x02,
+	.SerialNumStrIndex      = USE_INTERNAL_SERIAL,
+
+	.NumberOfConfigurations = FIXED_NUM_CONFIGURATIONS
+};
+
+/** Configuration descriptor structure. This descriptor, located in FLASH memory, describes the usage
+ *  of the device in one of its supported configurations, including information about any device interfaces
+ *  and endpoints. The descriptor is read out by the USB host during the enumeration process when selecting
+ *  a configuration so that the host may correctly communicate with the USB device.
+ */
+const USB_Descriptor_Configuration_t PROGMEM ConfigurationDescriptor =
+{
+	.Config =
+		{
+			.Header                   = {.Size = sizeof(USB_Descriptor_Configuration_Header_t), .Type = DTYPE_Configuration},
+
+			.TotalConfigurationSize   = sizeof(USB_Descriptor_Configuration_t),
+			.TotalInterfaces          = 2,
+
+			.ConfigurationNumber      = 1,
+			.ConfigurationStrIndex    = NO_DESCRIPTOR,
+
+			.ConfigAttributes         = (USB_CONFIG_ATTR_BUSPOWERED | USB_CONFIG_ATTR_SELFPOWERED),
+
+			.MaxPowerConsumption      = USB_CONFIG_POWER_MA(100)
+		},
+
+	.Audio_ControlInterface =
+		{
+			.Header                   = {.Size = sizeof(USB_Descriptor_Interface_t), .Type = DTYPE_Interface},
+
+			.InterfaceNumber          = 0,
+			.AlternateSetting         = 0,
+
+			.TotalEndpoints           = 0,
+
+			.Class                    = AUDIO_CSCP_AudioClass,
+			.SubClass                 = AUDIO_CSCP_ControlSubclass,
+			.Protocol                 = AUDIO_CSCP_ControlProtocol,
+
+			.InterfaceStrIndex        = NO_DESCRIPTOR
+		},
+
+	.Audio_ControlInterface_SPC =
+		{
+			.Header                   = {.Size = sizeof(USB_Audio_Descriptor_Interface_AC_t), .Type = DTYPE_CSInterface},
+			.Subtype                  = AUDIO_DSUBTYPE_CSInterface_Header,
+
+			.ACSpecification          = VERSION_BCD(01.00),
+			.TotalLength              = sizeof(USB_Audio_Descriptor_Interface_AC_t),
+
+			.InCollection             = 1,
+			.InterfaceNumber          = 1,
+		},
+
+	.Audio_StreamInterface =
+		{
+			.Header                   = {.Size = sizeof(USB_Descriptor_Interface_t), .Type = DTYPE_Interface},
+
+			.InterfaceNumber          = 1,
+			.AlternateSetting         = 0,
+
+			.TotalEndpoints           = 2,
+
+			.Class                    = AUDIO_CSCP_AudioClass,
+			.SubClass                 = AUDIO_CSCP_MIDIStreamingSubclass,
+			.Protocol                 = AUDIO_CSCP_StreamingProtocol,
+
+			.InterfaceStrIndex        = NO_DESCRIPTOR
+		},
+
+	.Audio_StreamInterface_SPC =
+		{
+			.Header                   = {.Size = sizeof(USB_MIDI_Descriptor_AudioInterface_AS_t), .Type = DTYPE_CSInterface},
+			.Subtype                  = AUDIO_DSUBTYPE_CSInterface_General,
+
+			.AudioSpecification       = VERSION_BCD(01.00),
+
+			.TotalLength              = (sizeof(USB_Descriptor_Configuration_t) -
+			                             offsetof(USB_Descriptor_Configuration_t, Audio_StreamInterface_SPC))
+		},
+
+	.MIDI_In_Jack_Emb =
+		{
+			.Header                   = {.Size = sizeof(USB_MIDI_Descriptor_InputJack_t), .Type = DTYPE_CSInterface},
+			.Subtype                  = AUDIO_DSUBTYPE_CSInterface_InputTerminal,
+
+			.JackType                 = MIDI_JACKTYPE_Embedded,
+			.JackID                   = 0x01,
+
+			.JackStrIndex             = NO_DESCRIPTOR
+		},
+
+	.MIDI_In_Jack_Ext =
+		{
+			.Header                   = {.Size = sizeof(USB_MIDI_Descriptor_InputJack_t), .Type = DTYPE_CSInterface},
+			.Subtype                  = AUDIO_DSUBTYPE_CSInterface_InputTerminal,
+
+			.JackType                 = MIDI_JACKTYPE_External,
+			.JackID                   = 0x02,
+
+			.JackStrIndex             = NO_DESCRIPTOR
+		},
+
+	.MIDI_Out_Jack_Emb =
+		{
+			.Header                   = {.Size = sizeof(USB_MIDI_Descriptor_OutputJack_t), .Type = DTYPE_CSInterface},
+			.Subtype                  = AUDIO_DSUBTYPE_CSInterface_OutputTerminal,
+
+			.JackType                 = MIDI_JACKTYPE_Embedded,
+			.JackID                   = 0x03,
+
+			.NumberOfPins             = 1,
+			.SourceJackID             = {0x02},
+			.SourcePinID              = {0x01},
+
+			.JackStrIndex             = NO_DESCRIPTOR
+		},
+
+	.MIDI_Out_Jack_Ext =
+		{
+			.Header                   = {.Size = sizeof(USB_MIDI_Descriptor_OutputJack_t), .Type = DTYPE_CSInterface},
+			.Subtype                  = AUDIO_DSUBTYPE_CSInterface_OutputTerminal,
+
+			.JackType                 = MIDI_JACKTYPE_External,
+			.JackID                   = 0x04,
+
+			.NumberOfPins             = 1,
+			.SourceJackID             = {0x01},
+			.SourcePinID              = {0x01},
+
+			.JackStrIndex             = NO_DESCRIPTOR
+		},
+
+	.MIDI_In_Jack_Endpoint =
+		{
+			.Endpoint =
+				{
+					.Header              = {.Size = sizeof(USB_Audio_Descriptor_StreamEndpoint_Std_t), .Type = DTYPE_Endpoint},
+
+					.EndpointAddress     = (ENDPOINT_DESCRIPTOR_DIR_OUT | MIDI_STREAM_OUT_EPNUM),
+					.Attributes          = (EP_TYPE_BULK | ENDPOINT_ATTR_NO_SYNC | ENDPOINT_USAGE_DATA),
+					.EndpointSize        = MIDI_STREAM_EPSIZE,
+					.PollingIntervalMS   = 0x01
+				},
+
+			.Refresh                  = 0,
+			.SyncEndpointNumber       = 0
+		},
+
+	.MIDI_In_Jack_Endpoint_SPC =
+		{
+			.Header                   = {.Size = sizeof(USB_MIDI_Descriptor_Jack_Endpoint_t), .Type = DTYPE_CSEndpoint},
+			.Subtype                  = AUDIO_DSUBTYPE_CSEndpoint_General,
+
+			.TotalEmbeddedJacks       = 0x01,
+			.AssociatedJackID         = {0x01}
+		},
+
+	.MIDI_Out_Jack_Endpoint =
+		{
+			.Endpoint =
+				{
+					.Header              = {.Size = sizeof(USB_Audio_Descriptor_StreamEndpoint_Std_t), .Type = DTYPE_Endpoint},
+
+					.EndpointAddress     = (ENDPOINT_DESCRIPTOR_DIR_IN | MIDI_STREAM_IN_EPNUM),
+					.Attributes          = (EP_TYPE_BULK | ENDPOINT_ATTR_NO_SYNC | ENDPOINT_USAGE_DATA),
+					.EndpointSize        = MIDI_STREAM_EPSIZE,
+					.PollingIntervalMS   = 0x01
+				},
+
+			.Refresh                  = 0,
+			.SyncEndpointNumber       = 0
+		},
+
+	.MIDI_Out_Jack_Endpoint_SPC =
+		{
+			.Header                   = {.Size = sizeof(USB_MIDI_Descriptor_Jack_Endpoint_t), .Type = DTYPE_CSEndpoint},
+			.Subtype                  = AUDIO_DSUBTYPE_CSEndpoint_General,
+
+			.TotalEmbeddedJacks       = 0x01,
+			.AssociatedJackID         = {0x03}
+		}
+};
+
+/** Language descriptor structure. This descriptor, located in FLASH memory, is returned when the host requests
+ *  the string descriptor with index 0 (the first index). It is actually an array of 16-bit integers, which indicate
+ *  via the language ID table available at USB.org what languages the device supports for its string descriptors.
+ */
+const USB_Descriptor_String_t PROGMEM LanguageString =
+{
+	.Header                 = {.Size = USB_STRING_LEN(1), .Type = DTYPE_String},
+
+	.UnicodeString          = {LANGUAGE_ID_ENG}
+};
+
+/** Manufacturer descriptor string. This is a Unicode string containing the manufacturer's details in human readable
+ *  form, and is read out upon request by the host when the appropriate string ID is requested, listed in the Device
+ *  Descriptor.
+ */
+const USB_Descriptor_String_t PROGMEM ManufacturerString =
+{
+	.Header                 = {.Size = USB_STRING_LEN(7), .Type = DTYPE_String},
+
+	.UnicodeString          = L"HIDUINO"
+};
+
+/** Product descriptor string. This is a Unicode string containing the product's details in human readable form,
+ *  and is read out upon request by the host when the appropriate string ID is requested, listed in the Device
+ *  Descriptor.
+ */
+const USB_Descriptor_String_t PROGMEM ProductString =
+{
+	.Header                 = {.Size = USB_STRING_LEN(8), .Type = DTYPE_String},
+
+	.UnicodeString          = L"HIDUINO"
+};
+
+/** This function is called by the library when in device mode, and must be overridden (see library "USB Descriptors"
+ *  documentation) by the application code so that the address and size of a requested descriptor can be given
+ *  to the USB library. When the device receives a Get Descriptor request on the control endpoint, this function
+ *  is called so that the descriptor details can be passed back and the appropriate descriptor sent back to the
+ *  USB host.
+ */
+uint16_t CALLBACK_USB_GetDescriptor(const uint16_t wValue,
+                                    const uint8_t wIndex,
+                                    const void** const DescriptorAddress)
+{
+	const uint8_t  DescriptorType   = (wValue >> 8);
+	const uint8_t  DescriptorNumber = (wValue & 0xFF);
+
+	const void* Address = NULL;
+	uint16_t    Size    = NO_DESCRIPTOR;
+
+	switch (DescriptorType)
+	{
+		case DTYPE_Device:
+			Address = &DeviceDescriptor;
+			Size    = sizeof(USB_Descriptor_Device_t);
+			break;
+		case DTYPE_Configuration:
+			Address = &ConfigurationDescriptor;
+			Size    = sizeof(USB_Descriptor_Configuration_t);
+			break;
+		case DTYPE_String:
+			switch (DescriptorNumber)
+			{
+				case 0x00:
+					Address = &LanguageString;
+					Size    = pgm_read_byte(&LanguageString.Header.Size);
+					break;
+				case 0x01:
+					Address = &ManufacturerString;
+					Size    = pgm_read_byte(&ManufacturerString.Header.Size);
+					break;
+				case 0x02:
+					Address = &ProductString;
+					Size    = pgm_read_byte(&ProductString.Header.Size);
+					break;
+			}
+
+			break;
+	}
+
+	*DescriptorAddress = Address;
+	return Size;
+}
+

--- a/src/Experimental/HIDUINO_MIDI_SYSEX/Descriptors.h
+++ b/src/Experimental/HIDUINO_MIDI_SYSEX/Descriptors.h
@@ -1,0 +1,83 @@
+/*
+             LUFA Library
+     Copyright (C) Dean Camera, 2010.
+
+  dean [at] fourwalledcubicle [dot] com
+           www.lufa-lib.org
+*/
+
+/*
+  Copyright 2010  Dean Camera (dean [at] fourwalledcubicle [dot] com)
+
+  Permission to use, copy, modify, distribute, and sell this
+  software and its documentation for any purpose is hereby granted
+  without fee, provided that the above copyright notice appear in
+  all copies and that both that the copyright notice and this
+  permission notice and warranty disclaimer appear in supporting
+  documentation, and that the name of the author not be used in
+  advertising or publicity pertaining to distribution of the
+  software without specific, written prior permission.
+
+  The author disclaim all warranties with regard to this
+  software, including all implied warranties of merchantability
+  and fitness.  In no event shall the author be liable for any
+  special, indirect or consequential damages or any damages
+  whatsoever resulting from loss of use, data or profits, whether
+  in an action of contract, negligence or other tortious action,
+  arising out of or in connection with the use or performance of
+  this software.
+*/
+
+/** \file
+ *
+ *  Header file for Descriptors.c.
+ */
+
+#ifndef _DESCRIPTORS_H_
+#define _DESCRIPTORS_H_
+
+	/* Includes: */
+		#include <LUFA/Drivers/USB/USB.h>
+
+		#include <avr/pgmspace.h>
+
+	/* Macros: */
+		/** Endpoint number of the MIDI streaming data IN endpoint, for device-to-host data transfers. */
+		#define MIDI_STREAM_IN_EPNUM        2
+
+		/** Endpoint number of the MIDI streaming data OUT endpoint, for host-to-device data transfers. */
+		#define MIDI_STREAM_OUT_EPNUM       1
+
+		/** Endpoint size in bytes of the Audio isochronous streaming data IN and OUT endpoints. */
+		#define MIDI_STREAM_EPSIZE          64
+
+	/* Type Defines: */
+		/** Type define for the device configuration descriptor structure. This must be defined in the
+		 *  application code, as the configuration descriptor contains several sub-descriptors which
+		 *  vary between devices, and which describe the device's usage to the host.
+		 */
+		typedef struct
+		{
+			USB_Descriptor_Configuration_Header_t     Config;
+			USB_Descriptor_Interface_t                Audio_ControlInterface;
+			USB_Audio_Descriptor_Interface_AC_t       Audio_ControlInterface_SPC;
+			USB_Descriptor_Interface_t                Audio_StreamInterface;
+			USB_MIDI_Descriptor_AudioInterface_AS_t   Audio_StreamInterface_SPC;
+			USB_MIDI_Descriptor_InputJack_t           MIDI_In_Jack_Emb;
+			USB_MIDI_Descriptor_InputJack_t           MIDI_In_Jack_Ext;
+			USB_MIDI_Descriptor_OutputJack_t          MIDI_Out_Jack_Emb;
+			USB_MIDI_Descriptor_OutputJack_t          MIDI_Out_Jack_Ext;
+			USB_Audio_Descriptor_StreamEndpoint_Std_t MIDI_In_Jack_Endpoint;
+			USB_MIDI_Descriptor_Jack_Endpoint_t       MIDI_In_Jack_Endpoint_SPC;
+			USB_Audio_Descriptor_StreamEndpoint_Std_t MIDI_Out_Jack_Endpoint;
+			USB_MIDI_Descriptor_Jack_Endpoint_t       MIDI_Out_Jack_Endpoint_SPC;
+		} USB_Descriptor_Configuration_t;
+
+	/* Function Prototypes: */
+		uint16_t CALLBACK_USB_GetDescriptor(const uint16_t wValue,
+		                                    const uint8_t wIndex,
+		                                    const void** const DescriptorAddress)
+		                                    ATTR_WARN_UNUSED_RESULT ATTR_NON_NULL_PTR_ARG(3);
+
+#endif
+

--- a/src/Experimental/HIDUINO_MIDI_SYSEX/HIDUINO_MIDI.c
+++ b/src/Experimental/HIDUINO_MIDI_SYSEX/HIDUINO_MIDI.c
@@ -1,0 +1,228 @@
+/***********************************************************************
+ *  HIDUINO_MIDI Firmware v1.5
+ *  by Dimitri Diakopoulos (http://www.dimitridiakopoulos.com)
+ *  Music Technology: Interaction, Intelligence & Design - October 2011
+ *  http://mtiid.calarts.edu
+ *  http://www.dimitridiakopoulos.com
+ *  Based on the LUFA MIDI Demo by Dean Camera 
+ * 		- http://www.fourwalledcubicle.com/LUFA.php
+ ***********************************************************************/
+
+#include "HIDUINO_MIDI.h"
+
+MIDI_EventPacket_t MIDI_FROM_ARDUINO; 
+//MIDI_EventPacket_t MIDI_FROM_ARDUINO2; 
+
+// Counters to keep track of recieved bytes
+volatile uint8_t dCount = 0;
+volatile uint8_t sysEx = 0;
+volatile uint8_t complete = 0; 
+
+uint8_t tx_ticks = 0; 
+uint8_t rx_ticks = 0; 
+
+USB_ClassInfo_MIDI_Device_t MIDI_Interface =
+	{
+		.Config =
+			{
+				.StreamingInterfaceNumber = 1,
+
+				.DataINEndpointNumber      = MIDI_STREAM_IN_EPNUM,
+				.DataINEndpointSize        = MIDI_STREAM_EPSIZE,
+				.DataINEndpointDoubleBank  = false,
+
+				.DataOUTEndpointNumber     = MIDI_STREAM_OUT_EPNUM,
+				.DataOUTEndpointSize       = MIDI_STREAM_EPSIZE,
+				.DataOUTEndpointDoubleBank = false,
+			},
+	};
+
+	
+int main(void) {
+	
+	LEDs_TurnOffLEDs(LEDS_LED1);
+	LEDs_TurnOffLEDs(LEDS_LED2);
+	
+	SetupHardware();
+	
+	sei();
+	
+	for (;;) { 
+		
+		if (tx_ticks) 
+			tx_ticks--;
+		else if (tx_ticks == 0)
+			LEDs_TurnOffLEDs(LEDS_LED1);		
+							
+		if (rx_ticks) 
+			rx_ticks--;
+		else if (rx_ticks == 0)
+			LEDs_TurnOffLEDs(LEDS_LED2);
+		
+		MIDI_IN();
+		MIDI_OUT(); 
+
+		MIDI_Device_USBTask(&MIDI_Interface);
+		USB_USBTask();
+		
+	}
+	
+}
+
+
+// Configures the board hardware and chip peripherals for the demo's functionality.
+void SetupHardware(void) {
+
+	// Disable watchdog if enabled by bootloader/fuses
+	MCUSR &= ~(1 << WDRF);
+	wdt_disable();
+	
+	// Hardware Initialization  
+	Serial_Init(31250, false);
+	
+	LEDs_Init();
+	USB_Init();
+	
+	// Start the flush timer so that overflows occur rapidly to push received bytes to the USB interface
+	TCCR0B = (1 << CS02);
+			
+	// Serial Interrupts
+	UCSR1B = 0;
+	UCSR1B = ((1 << RXCIE1) | (1 << TXEN1) | (1 << RXEN1));
+	
+}
+
+
+// Event handler for the library USB Connection event. */
+void EVENT_USB_Device_Connect(void) {
+	LEDs_SetAllLEDs(LEDMASK_USB_ENUMERATING);
+}
+
+// Event handler for the library USB Disconnection event. */
+void EVENT_USB_Device_Disconnect(void) {
+	LEDs_SetAllLEDs(LEDMASK_USB_NOTREADY);
+}
+
+// Event handler for the library USB Configuration Changed event. */
+void EVENT_USB_Device_ConfigurationChanged(void) {
+	bool ConfigSuccess = true;
+	ConfigSuccess &= MIDI_Device_ConfigureEndpoints(&MIDI_Interface);
+	LEDs_SetAllLEDs(ConfigSuccess ? LEDMASK_USB_READY : LEDMASK_USB_ERROR);
+}
+
+// Event handler for the library USB Control Request reception event. */
+void EVENT_USB_Device_ControlRequest(void) {
+	MIDI_Device_ProcessControlRequest(&MIDI_Interface);
+}
+
+// MIDI_IN routine. Host -> Arduino.  
+void MIDI_IN(void) {
+
+	MIDI_EventPacket_t ReceivedMIDIEvent;
+
+	if (MIDI_Device_ReceiveEventPacket(&MIDI_Interface, &ReceivedMIDIEvent)) {
+		Serial_TxByte(ReceivedMIDIEvent.Data1);
+		Serial_TxByte(ReceivedMIDIEvent.Data2); 
+		Serial_TxByte(ReceivedMIDIEvent.Data3); 
+		LEDs_TurnOnLEDs(LEDS_LED2);
+		rx_ticks = 5000; 
+	}
+	
+}
+
+// MIDI_OUT routine. Arduino -> Host.  
+void MIDI_OUT(void) {
+	
+	if (complete == 1) {
+		
+		complete = 0;
+	
+		MIDI_EventPacket_t MIDIEvent = (MIDI_EventPacket_t) {
+			.CableNumber = 0,
+			.Command     = MIDI_FROM_ARDUINO.Command,
+			.Data1       = MIDI_FROM_ARDUINO.Data1, 
+			.Data2       = MIDI_FROM_ARDUINO.Data2, 
+			.Data3       = MIDI_FROM_ARDUINO.Data3,		
+		};
+		
+		
+		MIDI_Device_SendEventPacket(&MIDI_Interface, &MIDIEvent);
+		MIDI_Device_Flush(&MIDI_Interface);
+		
+		LEDs_TurnOnLEDs(LEDS_LED1);
+		tx_ticks = 5000; 
+
+	}
+	
+	
+}
+
+// Interrupt helper for MIDI_OUT. 
+ISR(USART1_RX_vect, ISR_BLOCK) {
+	
+	uint8_t ReceivedByte = UDR1;
+			
+	// Naieve MIDI parser with SysEx support. TODO: full MIDI protocol support. 
+	if (USB_DeviceState == DEVICE_STATE_Configured) {
+	
+		if ( (ReceivedByte >> 7 ) == 1 ) {
+
+			if (ReceivedByte == MIDI_CMD_SYSEX_START) {
+				memset(&MIDI_FROM_ARDUINO, 0, sizeof(MIDI_EventPacket_t));
+				MIDI_FROM_ARDUINO.Data1 = ReceivedByte;
+				MIDI_FROM_ARDUINO.Command = USBMIDI_SYSEX_START;
+				sysEx = 1;
+			}
+			else if (ReceivedByte == MIDI_CMD_SYSEX_STOP) {
+
+				switch (dCount) {
+					case 3:
+						memset(&MIDI_FROM_ARDUINO, 0, sizeof(MIDI_EventPacket_t));
+						MIDI_FROM_ARDUINO.Command = USBMIDI_SYSEX_STOP_1B;
+						MIDI_FROM_ARDUINO.Data1 = ReceivedByte;
+						break;
+					case 0:
+						MIDI_FROM_ARDUINO.Command = USBMIDI_SYSEX_STOP_2B;
+						MIDI_FROM_ARDUINO.Data2 = ReceivedByte;
+						break;
+					case 1:
+						MIDI_FROM_ARDUINO.Command = USBMIDI_SYSEX_STOP_3B;
+						MIDI_FROM_ARDUINO.Data3 = ReceivedByte;
+						break;
+				}
+				sysEx = 0;
+				complete = 1;
+			}
+			else {
+				memset(&MIDI_FROM_ARDUINO, 0, sizeof(MIDI_EventPacket_t));
+				MIDI_FROM_ARDUINO.Command = ReceivedByte >> 4;
+				MIDI_FROM_ARDUINO.Data1 = ReceivedByte;
+				sysEx = 0;
+			}
+			dCount = 0; 
+		}
+		else if ((ReceivedByte >> 7) == 0) {
+
+			switch (dCount) {
+				case 3:
+					memset(&MIDI_FROM_ARDUINO, 0, sizeof(MIDI_EventPacket_t));
+					MIDI_FROM_ARDUINO.Command = USBMIDI_SYSEX_START;
+					MIDI_FROM_ARDUINO.Data1 = ReceivedByte;
+					dCount = 0; 
+					break;
+				case 0:
+					MIDI_FROM_ARDUINO.Data2 = ReceivedByte;
+					dCount = 1; 
+					break;
+				case 1:
+					MIDI_FROM_ARDUINO.Data3 = ReceivedByte;
+					if (sysEx)
+						dCount = 3; 
+					else
+						dCount = 0; 
+					complete = 1;
+					break;
+			}
+		}
+	}
+}

--- a/src/Experimental/HIDUINO_MIDI_SYSEX/HIDUINO_MIDI.h
+++ b/src/Experimental/HIDUINO_MIDI_SYSEX/HIDUINO_MIDI.h
@@ -1,0 +1,85 @@
+/***********************************************************************
+ *  HIDUINO_MIDI Firmware v1.2
+ *  by Dimitri Diakopoulos (http://www.dimitridiakopoulos.com)
+ *  Music Technology: Interaction, Intelligence & Design - April 2011
+ *  http://mtiid.calarts.edu
+ *  http://www.dimitridiakopoulos.com
+ *  Based on the LUFA MIDI Demo by Dean Camera 
+ * 		- http://www.fourwalledcubicle.com/LUFA.php
+ ***********************************************************************/
+
+#ifndef _AUDIO_OUTPUT_H_
+#define _AUDIO_OUTPUT_H_
+
+	/* Includes: */
+		#include <avr/io.h>
+		#include <avr/wdt.h>
+		#include <avr/power.h>
+		#include <avr/interrupt.h>
+		#include <stdbool.h>
+		#include <string.h>
+
+		#include "Descriptors.h"
+				
+		#include <LUFA/Version.h>
+		#include <LUFA/Drivers/Board/LEDs.h>
+		#include <LUFA/Drivers/Peripheral/Serial.h>
+		#include <LUFA/Drivers/USB/USB.h>
+		#include <LUFA/Drivers/USB/Class/MIDI.h>
+
+	/* Macros: */
+		/** LED mask for the library LED driver, to indicate that the USB interface is not ready. */
+		#define LEDMASK_USB_NOTREADY      LEDS_LED1
+
+		/** LED mask for the library LED driver, to indicate that the USB interface is enumerating. */
+		#define LEDMASK_USB_ENUMERATING  (LEDS_LED2 | LEDS_LED3)
+
+		/** LED mask for the library LED driver, to indicate that the USB interface is ready. */
+		#define LEDMASK_USB_READY        (LEDS_LED2 | LEDS_LED4)
+
+		/** LED mask for the library LED driver, to indicate that an error has occurred in the USB interface. */
+		#define LEDMASK_USB_ERROR        (LEDS_LED1 | LEDS_LED3)
+		
+		/** LED mask for the library LED driver, to indicate TX activity. */
+		#define LEDMASK_TX               LEDS_LED1
+
+		/** LED mask for the library LED driver, to indicate RX activity. */
+		#define LEDMASK_RX               LEDS_LED2
+		
+		#define	MIDI_CMD_NOTE_ON         0x90
+		#define	MIDI_CMD_NOTE_OFF	 	     0x80
+		#define	MIDI_CMD_CC              0xB0
+		#define	MIDI_CMD_PB              0xE0
+		#define MIDI_CMD_SYSEX_START     0xF0   
+		#define MIDI_CMD_SYSEX_STOP      0xF7  
+		
+		/** Two-byte System Common messages like MTC, SongSelect, etc.*/
+		#define USBMIDI_COMMON_2B 0x2 
+
+		/** Three-byte System Common messages like SPP, etc. */
+		#define USBMIDI_COMMON_3B 0x3  
+
+		/** SysEx starts or continues */
+		#define USBMIDI_SYSEX_START 0x4  		
+
+		/** Single-byte System Common Message or SysEx ends with following single byte*/
+		#define USBMIDI_SYSEX_STOP_1B 0x5
+
+		/** SysEx ends with following two bytes. */
+		#define USBMIDI_SYSEX_STOP_2B 0x6
+
+		/** SysEx ends with following three bytes. */
+		#define USBMIDI_SYSEX_STOP_3B 0x7 
+
+	/* Function Prototypes: */
+		void SetupHardware(void);
+		
+		void MIDI_OUT(void); 
+		void MIDI_IN(void);
+
+		void EVENT_USB_Device_Connect(void);
+		void EVENT_USB_Device_Disconnect(void);
+		void EVENT_USB_Device_ConfigurationChanged(void);
+		void EVENT_USB_Device_UnhandledControlRequest(void);
+
+#endif

--- a/src/Experimental/HIDUINO_MIDI_SYSEX/makefile
+++ b/src/Experimental/HIDUINO_MIDI_SYSEX/makefile
@@ -1,0 +1,723 @@
+# Hey Emacs, this is a -*- makefile -*-
+#----------------------------------------------------------------------------
+# WinAVR Makefile Template written by Eric B. Weddington, Jörg Wunsch, et al.
+#  >> Modified for use with the LUFA project. <<
+#
+# Released to the Public Domain
+#
+# Additional material for this makefile was written by:
+# Peter Fleury
+# Tim Henigan
+# Colin O'Flynn
+# Reiner Patommel
+# Markus Pfaff
+# Sander Pool
+# Frederik Rouleau
+# Carlos Lamas
+# Dean Camera
+# Opendous Inc.
+# Denver Gingerich
+#
+#----------------------------------------------------------------------------
+# On command line:
+#
+# make all = Make software.
+#
+# make clean = Clean out built project files.
+#
+# make coff = Convert ELF to AVR COFF.
+#
+# make extcoff = Convert ELF to AVR Extended COFF.
+#
+# make program = Download the hex file to the device, using avrdude.
+#                Please customize the avrdude settings below first!
+#
+# make dfu = Download the hex file to the device, using dfu-programmer (must
+#            have dfu-programmer installed).
+#
+# make flip = Download the hex file to the device, using Atmel FLIP (must
+#             have Atmel FLIP installed).
+#
+# make dfu-ee = Download the eeprom file to the device, using dfu-programmer
+#               (must have dfu-programmer installed).
+#
+# make flip-ee = Download the eeprom file to the device, using Atmel FLIP
+#                (must have Atmel FLIP installed).
+#
+# make doxygen = Generate DoxyGen documentation for the project (must have
+#                DoxyGen installed)
+#
+# make debug = Start either simulavr or avarice as specified for debugging, 
+#              with avr-gdb or avr-insight as the front end for debugging.
+#
+# make filename.s = Just compile filename.c into the assembler code only.
+#
+# make filename.i = Create a preprocessed source file for use in submitting
+#                   bug reports to the GCC project.
+#
+# To rebuild project do "make clean" then "make all".
+#----------------------------------------------------------------------------
+
+
+# MCU name
+MCU = atmega8u2
+MCU_AVRDUDE = at90usb82
+MCU_DFU = at90usb82
+
+# Specify the Arduino model using the assigned PID.  This is used by Descriptors.c
+#   to set PID and product descriptor string
+# Uno PID:
+#ARDUINO_MODEL_PID = 0x0001
+# Mega 2560 PID:
+ARDUINO_MODEL_PID = 0x0010
+
+# Target board (see library "Board Types" documentation, NONE for projects not requiring
+# LUFA board drivers). If USER is selected, put custom board drivers in a directory called 
+# "Board" inside the application directory.
+BOARD  = USER
+
+
+# Processor frequency.
+#     This will define a symbol, F_CPU, in all source code files equal to the 
+#     processor frequency in Hz. You can then use this symbol in your source code to 
+#     calculate timings. Do NOT tack on a 'UL' at the end, this will be done
+#     automatically to create a 32-bit value in your source code.
+#
+#     This will be an integer division of F_CLOCK below, as it is sourced by
+#     F_CLOCK after it has run through any CPU prescalers. Note that this value
+#     does not *change* the processor frequency - it should merely be updated to
+#     reflect the processor speed set externally so that the code can use accurate
+#     software delays.
+F_CPU = 16000000
+
+
+# Input clock frequency.
+#     This will define a symbol, F_CLOCK, in all source code files equal to the 
+#     input clock frequency (before any prescaling is performed) in Hz. This value may
+#     differ from F_CPU if prescaling is used on the latter, and is required as the
+#     raw input clock is fed directly to the PLL sections of the AVR for high speed
+#     clock generation for the USB and other AVR subsections. Do NOT tack on a 'UL'
+#     at the end, this will be done automatically to create a 32-bit value in your
+#     source code.
+#
+#     If no clock division is performed on the input clock inside the AVR (via the
+#     CPU clock adjust registers or the clock division fuses), this will be equal to F_CPU.
+F_CLOCK = $(F_CPU)
+
+
+# Output format. (can be srec, ihex, binary)
+FORMAT = ihex
+
+
+# Target file name (without extension).
+TARGET = HIDUINO_MIDI
+
+
+# Object files directory
+#     To put object files in current directory, use a dot (.), do NOT make
+#     this an empty or blank macro!
+OBJDIR = .
+
+
+# Path to the LUFA library
+LUFA_PATH = ../..
+
+
+# LUFA library compile-time options and predefined tokens
+LUFA_OPTS  = -D USB_DEVICE_ONLY
+LUFA_OPTS += -D FIXED_CONTROL_ENDPOINT_SIZE=8
+LUFA_OPTS += -D FIXED_NUM_CONFIGURATIONS=1
+LUFA_OPTS += -D USE_FLASH_DESCRIPTORS
+LUFA_OPTS += -D USE_STATIC_OPTIONS="(USB_DEVICE_OPT_FULLSPEED | USB_OPT_REG_ENABLED | USB_OPT_AUTO_PLL)"
+
+
+# Create the LUFA source path variables by including the LUFA root makefile
+include $(LUFA_PATH)/LUFA/makefile
+
+
+# List C source files here. (C dependencies are automatically generated.)
+SRC = $(TARGET).c                                                 \
+	  Descriptors.c                                               \
+	  $(LUFA_SRC_USB)                                             \
+	  $(LUFA_SRC_USBCLASS)
+
+
+# List C++ source files here. (C dependencies are automatically generated.)
+CPPSRC = 
+
+
+# List Assembler source files here.
+#     Make them always end in a capital .S.  Files ending in a lowercase .s
+#     will not be considered source files but generated files (assembler
+#     output from the compiler), and will be deleted upon "make clean"!
+#     Even though the DOS/Win* filesystem matches both .s and .S the same,
+#     it will preserve the spelling of the filenames, and gcc itself does
+#     care about how the name is spelled on its command-line.
+ASRC =
+
+
+# Optimization level, can be [0, 1, 2, 3, s]. 
+#     0 = turn off optimization. s = optimize for size.
+#     (Note: 3 is not always the best optimization level. See avr-libc FAQ.)
+OPT = s
+
+
+# Debugging format.
+#     Native formats for AVR-GCC's -g are dwarf-2 [default] or stabs.
+#     AVR Studio 4.10 requires dwarf-2.
+#     AVR [Extended] COFF format requires stabs, plus an avr-objcopy run.
+DEBUG = dwarf-2
+
+
+# List any extra directories to look for include files here.
+#     Each directory must be seperated by a space.
+#     Use forward slashes for directory separators.
+#     For a directory that has spaces, enclose it in quotes.
+EXTRAINCDIRS = $(LUFA_PATH)/
+
+
+# Compiler flag to set the C Standard level.
+#     c89   = "ANSI" C
+#     gnu89 = c89 plus GCC extensions
+#     c99   = ISO C99 standard (not yet fully implemented)
+#     gnu99 = c99 plus GCC extensions
+CSTANDARD = -std=c99
+
+
+# Place -D or -U options here for C sources
+CDEFS  = -DF_CPU=$(F_CPU)UL
+CDEFS += -DF_CLOCK=$(F_CLOCK)UL
+CDEFS += -DARDUINO_MODEL_PID=$(ARDUINO_MODEL_PID)
+CDEFS += -DBOARD=BOARD_$(BOARD)
+CDEFS += $(LUFA_OPTS)
+CDEFS += -DTX_RX_LED_PULSE_MS=3
+CDEFS += -DPING_PONG_LED_PULSE_MS=100
+
+
+# Place -D or -U options here for ASM sources
+ADEFS  = -DF_CPU=$(F_CPU)
+ADEFS += -DF_CLOCK=$(F_CLOCK)UL
+ADEFS += -DBOARD=BOARD_$(BOARD)
+ADEFS += $(LUFA_OPTS)
+
+# Place -D or -U options here for C++ sources
+CPPDEFS  = -DF_CPU=$(F_CPU)UL
+CPPDEFS += -DF_CLOCK=$(F_CLOCK)UL
+CPPDEFS += -DBOARD=BOARD_$(BOARD)
+CPPDEFS += $(LUFA_OPTS)
+#CPPDEFS += -D__STDC_LIMIT_MACROS
+#CPPDEFS += -D__STDC_CONSTANT_MACROS
+
+
+
+#---------------- Compiler Options C ----------------
+#  -g*:          generate debugging information
+#  -O*:          optimization level
+#  -f...:        tuning, see GCC manual and avr-libc documentation
+#  -Wall...:     warning level
+#  -Wa,...:      tell GCC to pass this to the assembler.
+#    -adhlns...: create assembler listing
+CFLAGS = -g$(DEBUG)
+CFLAGS += $(CDEFS)
+CFLAGS += -O$(OPT)
+CFLAGS += -funsigned-char
+CFLAGS += -funsigned-bitfields
+CFLAGS += -ffunction-sections
+CFLAGS += -fno-inline-small-functions
+CFLAGS += -fpack-struct
+CFLAGS += -fshort-enums
+CFLAGS += -fno-strict-aliasing
+CFLAGS += -Wall
+CFLAGS += -Wstrict-prototypes
+#CFLAGS += -mshort-calls
+#CFLAGS += -fno-unit-at-a-time
+#CFLAGS += -Wundef
+#CFLAGS += -Wunreachable-code
+#CFLAGS += -Wsign-compare
+CFLAGS += -Wa,-adhlns=$(<:%.c=$(OBJDIR)/%.lst)
+CFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
+CFLAGS += $(CSTANDARD)
+
+
+#---------------- Compiler Options C++ ----------------
+#  -g*:          generate debugging information
+#  -O*:          optimization level
+#  -f...:        tuning, see GCC manual and avr-libc documentation
+#  -Wall...:     warning level
+#  -Wa,...:      tell GCC to pass this to the assembler.
+#    -adhlns...: create assembler listing
+CPPFLAGS = -g$(DEBUG)
+CPPFLAGS += $(CPPDEFS)
+CPPFLAGS += -O$(OPT)
+CPPFLAGS += -funsigned-char
+CPPFLAGS += -funsigned-bitfields
+CPPFLAGS += -fpack-struct
+CPPFLAGS += -fshort-enums
+CPPFLAGS += -fno-exceptions
+CPPFLAGS += -Wall
+CPPFLAGS += -Wundef
+#CPPFLAGS += -mshort-calls
+#CPPFLAGS += -fno-unit-at-a-time
+#CPPFLAGS += -Wstrict-prototypes
+#CPPFLAGS += -Wunreachable-code
+#CPPFLAGS += -Wsign-compare
+CPPFLAGS += -Wa,-adhlns=$(<:%.cpp=$(OBJDIR)/%.lst)
+CPPFLAGS += $(patsubst %,-I%,$(EXTRAINCDIRS))
+#CPPFLAGS += $(CSTANDARD)
+
+
+#---------------- Assembler Options ----------------
+#  -Wa,...:   tell GCC to pass this to the assembler.
+#  -adhlns:   create listing
+#  -gstabs:   have the assembler create line number information; note that
+#             for use in COFF files, additional information about filenames
+#             and function names needs to be present in the assembler source
+#             files -- see avr-libc docs [FIXME: not yet described there]
+#  -listing-cont-lines: Sets the maximum number of continuation lines of hex 
+#       dump that will be displayed for a given single line of source input.
+ASFLAGS = $(ADEFS) -Wa,-adhlns=$(<:%.S=$(OBJDIR)/%.lst),-gstabs,--listing-cont-lines=100
+
+
+#---------------- Library Options ----------------
+# Minimalistic printf version
+PRINTF_LIB_MIN = -Wl,-u,vfprintf -lprintf_min
+
+# Floating point printf version (requires MATH_LIB = -lm below)
+PRINTF_LIB_FLOAT = -Wl,-u,vfprintf -lprintf_flt
+
+# If this is left blank, then it will use the Standard printf version.
+PRINTF_LIB = 
+#PRINTF_LIB = $(PRINTF_LIB_MIN)
+#PRINTF_LIB = $(PRINTF_LIB_FLOAT)
+
+
+# Minimalistic scanf version
+SCANF_LIB_MIN = -Wl,-u,vfscanf -lscanf_min
+
+# Floating point + %[ scanf version (requires MATH_LIB = -lm below)
+SCANF_LIB_FLOAT = -Wl,-u,vfscanf -lscanf_flt
+
+# If this is left blank, then it will use the Standard scanf version.
+SCANF_LIB = 
+#SCANF_LIB = $(SCANF_LIB_MIN)
+#SCANF_LIB = $(SCANF_LIB_FLOAT)
+
+
+MATH_LIB = -lm
+
+
+# List any extra directories to look for libraries here.
+#     Each directory must be seperated by a space.
+#     Use forward slashes for directory separators.
+#     For a directory that has spaces, enclose it in quotes.
+EXTRALIBDIRS = 
+
+
+
+#---------------- External Memory Options ----------------
+
+# 64 KB of external RAM, starting after internal RAM (ATmega128!),
+# used for variables (.data/.bss) and heap (malloc()).
+#EXTMEMOPTS = -Wl,-Tdata=0x801100,--defsym=__heap_end=0x80ffff
+
+# 64 KB of external RAM, starting after internal RAM (ATmega128!),
+# only used for heap (malloc()).
+#EXTMEMOPTS = -Wl,--section-start,.data=0x801100,--defsym=__heap_end=0x80ffff
+
+EXTMEMOPTS =
+
+
+
+#---------------- Linker Options ----------------
+#  -Wl,...:     tell GCC to pass this to linker.
+#    -Map:      create map file
+#    --cref:    add cross reference to  map file
+LDFLAGS  = -Wl,-Map=$(TARGET).map,--cref
+LDFLAGS += -Wl,--relax 
+LDFLAGS += -Wl,--gc-sections
+LDFLAGS += $(EXTMEMOPTS)
+LDFLAGS += $(patsubst %,-L%,$(EXTRALIBDIRS))
+LDFLAGS += $(PRINTF_LIB) $(SCANF_LIB) $(MATH_LIB)
+#LDFLAGS += -T linker_script.x
+
+
+
+#---------------- Programming Options (avrdude) ----------------
+
+# Programming hardware
+# Type: avrdude -c ?
+# to get a full listing.
+#
+AVRDUDE_PROGRAMMER = avrispmkii
+
+# com1 = serial port. Use lpt1 to connect to parallel port.
+AVRDUDE_PORT = usb
+
+AVRDUDE_WRITE_FLASH = -U flash:w:$(TARGET).hex
+#AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
+
+
+# Uncomment the following if you want avrdude's erase cycle counter.
+# Note that this counter needs to be initialized first using -Yn,
+# see avrdude manual.
+#AVRDUDE_ERASE_COUNTER = -y
+
+# Uncomment the following if you do /not/ wish a verification to be
+# performed after programming the device.
+#AVRDUDE_NO_VERIFY = -V
+
+# Increase verbosity level.  Please use this when submitting bug
+# reports about avrdude. See <http://savannah.nongnu.org/projects/avrdude> 
+# to submit bug reports.
+#AVRDUDE_VERBOSE = -v -v
+
+AVRDUDE_FLAGS = -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
+AVRDUDE_FLAGS += $(AVRDUDE_NO_VERIFY)
+AVRDUDE_FLAGS += $(AVRDUDE_VERBOSE)
+AVRDUDE_FLAGS += $(AVRDUDE_ERASE_COUNTER)
+
+
+
+#---------------- Debugging Options ----------------
+
+# For simulavr only - target MCU frequency.
+DEBUG_MFREQ = $(F_CPU)
+
+# Set the DEBUG_UI to either gdb or insight.
+# DEBUG_UI = gdb
+DEBUG_UI = insight
+
+# Set the debugging back-end to either avarice, simulavr.
+DEBUG_BACKEND = avarice
+#DEBUG_BACKEND = simulavr
+
+# GDB Init Filename.
+GDBINIT_FILE = __avr_gdbinit
+
+# When using avarice settings for the JTAG
+JTAG_DEV = /dev/com1
+
+# Debugging port used to communicate between GDB / avarice / simulavr.
+DEBUG_PORT = 4242
+
+# Debugging host used to communicate between GDB / avarice / simulavr, normally
+#     just set to localhost unless doing some sort of crazy debugging when 
+#     avarice is running on a different computer.
+DEBUG_HOST = localhost
+
+
+
+#============================================================================
+
+
+# Define programs and commands.
+SHELL = sh
+CC = avr-gcc
+OBJCOPY = avr-objcopy
+OBJDUMP = avr-objdump
+SIZE = avr-size
+AR = avr-ar rcs
+NM = avr-nm
+AVRDUDE = avrdude
+REMOVE = rm -f
+REMOVEDIR = rm -rf
+COPY = cp
+WINSHELL = cmd
+
+
+# Define Messages
+# English
+MSG_ERRORS_NONE = Errors: none
+MSG_BEGIN = -------- begin --------
+MSG_END = --------  end  --------
+MSG_SIZE_BEFORE = Size before: 
+MSG_SIZE_AFTER = Size after:
+MSG_COFF = Converting to AVR COFF:
+MSG_EXTENDED_COFF = Converting to AVR Extended COFF:
+MSG_FLASH = Creating load file for Flash:
+MSG_EEPROM = Creating load file for EEPROM:
+MSG_EXTENDED_LISTING = Creating Extended Listing:
+MSG_SYMBOL_TABLE = Creating Symbol Table:
+MSG_LINKING = Linking:
+MSG_COMPILING = Compiling C:
+MSG_COMPILING_CPP = Compiling C++:
+MSG_ASSEMBLING = Assembling:
+MSG_CLEANING = Cleaning project:
+MSG_CREATING_LIBRARY = Creating library:
+
+
+
+
+# Define all object files.
+OBJ = $(SRC:%.c=$(OBJDIR)/%.o) $(CPPSRC:%.cpp=$(OBJDIR)/%.o) $(ASRC:%.S=$(OBJDIR)/%.o) 
+
+# Define all listing files.
+LST = $(SRC:%.c=$(OBJDIR)/%.lst) $(CPPSRC:%.cpp=$(OBJDIR)/%.lst) $(ASRC:%.S=$(OBJDIR)/%.lst) 
+
+
+# Compiler flags to generate dependency files.
+GENDEPFLAGS = -MMD -MP -MF .dep/$(@F).d
+
+
+# Combine all necessary flags and optional flags.
+# Add target processor to flags.
+ALL_CFLAGS = -mmcu=$(MCU) -I. $(CFLAGS) $(GENDEPFLAGS)
+ALL_CPPFLAGS = -mmcu=$(MCU) -I. -x c++ $(CPPFLAGS) $(GENDEPFLAGS)
+ALL_ASFLAGS = -mmcu=$(MCU) -I. -x assembler-with-cpp $(ASFLAGS)
+
+
+
+
+
+# Default target.
+all: begin gccversion sizebefore build sizeafter end
+
+# Change the build target to build a HEX file or a library.
+build: elf hex eep lss sym
+#build: lib
+
+
+elf: $(TARGET).elf
+hex: $(TARGET).hex
+eep: $(TARGET).eep
+lss: $(TARGET).lss
+sym: $(TARGET).sym
+LIBNAME=lib$(TARGET).a
+lib: $(LIBNAME)
+
+
+
+# Eye candy.
+# AVR Studio 3.x does not check make's exit code but relies on
+# the following magic strings to be generated by the compile job.
+begin:
+	@echo
+	@echo $(MSG_BEGIN)
+
+end:
+	@echo $(MSG_END)
+	@echo
+
+
+# Display size of file.
+HEXSIZE = $(SIZE) --target=$(FORMAT) $(TARGET).hex
+ELFSIZE = $(SIZE) $(MCU_FLAG) $(FORMAT_FLAG) $(TARGET).elf
+MCU_FLAG = $(shell $(SIZE) --help | grep -- --mcu > /dev/null && echo --mcu=$(MCU) )
+FORMAT_FLAG = $(shell $(SIZE) --help | grep -- --format=.*avr > /dev/null && echo --format=avr )
+
+
+sizebefore:
+	@if test -f $(TARGET).elf; then echo; echo $(MSG_SIZE_BEFORE); $(ELFSIZE); \
+	2>/dev/null; echo; fi
+
+sizeafter:
+	@if test -f $(TARGET).elf; then echo; echo $(MSG_SIZE_AFTER); $(ELFSIZE); \
+	2>/dev/null; echo; fi
+
+
+
+# Display compiler version information.
+gccversion : 
+	@$(CC) --version
+
+
+# Program the device.  
+program: $(TARGET).hex $(TARGET).eep
+	$(AVRDUDE) $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_FLASH) $(AVRDUDE_WRITE_EEPROM)
+
+flip: $(TARGET).hex
+	batchisp -hardware usb -device $(MCU) -operation erase f
+	batchisp -hardware usb -device $(MCU) -operation loadbuffer $(TARGET).hex program
+	batchisp -hardware usb -device $(MCU) -operation start reset 0
+
+dfu: $(TARGET).hex
+	dfu-programmer $(MCU) erase
+	dfu-programmer $(MCU) flash --debug 1 $(TARGET).hex
+	dfu-programmer $(MCU) reset
+
+flip-ee: $(TARGET).hex $(TARGET).eep
+	$(COPY) $(TARGET).eep $(TARGET)eep.hex
+	batchisp -hardware usb -device $(MCU) -operation memory EEPROM erase
+	batchisp -hardware usb -device $(MCU) -operation memory EEPROM loadbuffer $(TARGET)eep.hex program
+	batchisp -hardware usb -device $(MCU) -operation start reset 0
+	$(REMOVE) $(TARGET)eep.hex
+
+dfu-ee: $(TARGET).hex $(TARGET).eep
+	dfu-programmer $(MCU) flash-eeprom --debug 1 --suppress-bootloader-mem $(TARGET).eep
+	dfu-programmer $(MCU) reset
+
+
+# Generate avr-gdb config/init file which does the following:
+#     define the reset signal, load the target file, connect to target, and set 
+#     a breakpoint at main().
+gdb-config: 
+	@$(REMOVE) $(GDBINIT_FILE)
+	@echo define reset >> $(GDBINIT_FILE)
+	@echo SIGNAL SIGHUP >> $(GDBINIT_FILE)
+	@echo end >> $(GDBINIT_FILE)
+	@echo file $(TARGET).elf >> $(GDBINIT_FILE)
+	@echo target remote $(DEBUG_HOST):$(DEBUG_PORT)  >> $(GDBINIT_FILE)
+ifeq ($(DEBUG_BACKEND),simulavr)
+	@echo load  >> $(GDBINIT_FILE)
+endif
+	@echo break main >> $(GDBINIT_FILE)
+
+debug: gdb-config $(TARGET).elf
+ifeq ($(DEBUG_BACKEND), avarice)
+	@echo Starting AVaRICE - Press enter when "waiting to connect" message displays.
+	@$(WINSHELL) /c start avarice --jtag $(JTAG_DEV) --erase --program --file \
+	$(TARGET).elf $(DEBUG_HOST):$(DEBUG_PORT)
+	@$(WINSHELL) /c pause
+
+else
+	@$(WINSHELL) /c start simulavr --gdbserver --device $(MCU) --clock-freq \
+	$(DEBUG_MFREQ) --port $(DEBUG_PORT)
+endif
+	@$(WINSHELL) /c start avr-$(DEBUG_UI) --command=$(GDBINIT_FILE)
+
+
+
+
+# Convert ELF to COFF for use in debugging / simulating in AVR Studio or VMLAB.
+COFFCONVERT = $(OBJCOPY) --debugging
+COFFCONVERT += --change-section-address .data-0x800000
+COFFCONVERT += --change-section-address .bss-0x800000
+COFFCONVERT += --change-section-address .noinit-0x800000
+COFFCONVERT += --change-section-address .eeprom-0x810000
+
+
+
+coff: $(TARGET).elf
+	@echo
+	@echo $(MSG_COFF) $(TARGET).cof
+	$(COFFCONVERT) -O coff-avr $< $(TARGET).cof
+
+
+extcoff: $(TARGET).elf
+	@echo
+	@echo $(MSG_EXTENDED_COFF) $(TARGET).cof
+	$(COFFCONVERT) -O coff-ext-avr $< $(TARGET).cof
+
+
+
+# Create final output files (.hex, .eep) from ELF output file.
+%.hex: %.elf
+	@echo
+	@echo $(MSG_FLASH) $@
+	$(OBJCOPY) -O $(FORMAT) -R .eeprom -R .fuse -R .lock $< $@
+
+%.eep: %.elf
+	@echo
+	@echo $(MSG_EEPROM) $@
+	-$(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" \
+	--change-section-lma .eeprom=0 --no-change-warnings -O $(FORMAT) $< $@ || exit 0
+
+# Create extended listing file from ELF output file.
+%.lss: %.elf
+	@echo
+	@echo $(MSG_EXTENDED_LISTING) $@
+	$(OBJDUMP) -h -S -z $< > $@
+
+# Create a symbol table from ELF output file.
+%.sym: %.elf
+	@echo
+	@echo $(MSG_SYMBOL_TABLE) $@
+	$(NM) -n $< > $@
+
+
+
+# Create library from object files.
+.SECONDARY : $(TARGET).a
+.PRECIOUS : $(OBJ)
+%.a: $(OBJ)
+	@echo
+	@echo $(MSG_CREATING_LIBRARY) $@
+	$(AR) $@ $(OBJ)
+
+
+# Link: create ELF output file from object files.
+.SECONDARY : $(TARGET).elf
+.PRECIOUS : $(OBJ)
+%.elf: $(OBJ)
+	@echo
+	@echo $(MSG_LINKING) $@
+	$(CC) $(ALL_CFLAGS) $^ --output $@ $(LDFLAGS)
+
+
+# Compile: create object files from C source files.
+$(OBJDIR)/%.o : %.c
+	@echo
+	@echo $(MSG_COMPILING) $<
+	$(CC) -c $(ALL_CFLAGS) $< -o $@ 
+
+
+# Compile: create object files from C++ source files.
+$(OBJDIR)/%.o : %.cpp
+	@echo
+	@echo $(MSG_COMPILING_CPP) $<
+	$(CC) -c $(ALL_CPPFLAGS) $< -o $@ 
+
+
+# Compile: create assembler files from C source files.
+%.s : %.c
+	$(CC) -S $(ALL_CFLAGS) $< -o $@
+
+
+# Compile: create assembler files from C++ source files.
+%.s : %.cpp
+	$(CC) -S $(ALL_CPPFLAGS) $< -o $@
+
+
+# Assemble: create object files from assembler source files.
+$(OBJDIR)/%.o : %.S
+	@echo
+	@echo $(MSG_ASSEMBLING) $<
+	$(CC) -c $(ALL_ASFLAGS) $< -o $@
+
+
+# Create preprocessed source for use in sending a bug report.
+%.i : %.c
+	$(CC) -E -mmcu=$(MCU) -I. $(CFLAGS) $< -o $@ 
+
+
+# Target: clean project.
+clean: begin clean_list end
+
+clean_list :
+	@echo
+	@echo $(MSG_CLEANING)
+	$(REMOVE) $(TARGET).hex
+	$(REMOVE) $(TARGET).eep
+	$(REMOVE) $(TARGET).cof
+	$(REMOVE) $(TARGET).elf
+	$(REMOVE) $(TARGET).map
+	$(REMOVE) $(TARGET).sym
+	$(REMOVE) $(TARGET).lss
+	$(REMOVE) $(SRC:%.c=$(OBJDIR)/%.o)
+	$(REMOVE) $(SRC:%.c=$(OBJDIR)/%.lst)
+	$(REMOVE) $(SRC:.c=.s)
+	$(REMOVE) $(SRC:.c=.d)
+	$(REMOVE) $(SRC:.c=.i)
+	$(REMOVEDIR) .dep
+
+doxygen:
+	@echo Generating Project Documentation...
+	@doxygen Doxygen.conf
+	@echo Documentation Generation Complete.
+
+clean_doxygen:
+	rm -rf Documentation
+
+# Create object files directory
+$(shell mkdir $(OBJDIR) 2>/dev/null)
+
+
+# Include the dependency files.
+-include $(shell mkdir .dep 2>/dev/null) $(wildcard .dep/*)
+
+
+# Listing of phony targets.
+.PHONY : all begin finish end sizebefore sizeafter gccversion \
+build elf hex eep lss sym coff extcoff doxygen clean          \
+clean_list clean_doxygen program dfu flip flip-ee dfu-ee      \
+debug gdb-config


### PR DESCRIPTION
Changed the ISR handler to support sysex. Added as
src/Experimantal/HIDUINO_MIDI_SYSEX. Some smaller changes to
make it compile with LUFA101122 and avr-gcc 4.7.0 (const
for PROGMEM). Added a gitignore too.

Signed-off-by: Kaspar Bumke kaspar.bumke@gmail.com
